### PR TITLE
Removing sides switch at end of the half and team names are now param of binary

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,23 @@ int main(int argc, char *argv[])
     QObject::connect(refView->getUI(), SIGNAL(sendManualCommand(VSSRef::Foul, VSSRef::Color, VSSRef::Quadrant)), vssReferee, SLOT(takeManualCommand(VSSRef::Foul, VSSRef::Color, VSSRef::Quadrant)));
 
     /// Set team
+    // Command line parser, get arguments
+    QCommandLineParser parser;
+    parser.setApplicationDescription("VSSReferee application help.");
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addPositionalArgument("teamBlueName", "Sets the team blue name");
+    parser.addPositionalArgument("teamYellowName", "Sets the team yellow name");
+    parser.process(a);
+    QStringList args = parser.positionalArguments();
+
+    // Setting default (by json)
     refView->setTeams(constants->getLeftTeamName(), constants->getLeftTeamColor(), constants->getRightTeamName(), constants->getRightTeamColor());
+
+    // Setting by args
+    if(args.size() >= 2){
+        refView->setTeams(args.at(0), VSSRef::Color::BLUE, args.at(1), VSSRef::Color::YELLOW);
+    }
 
     /// Start all
     vssVisionClient->start();

--- a/main.cpp
+++ b/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     QObject::connect(vssReplacer, SIGNAL(teamPlaced(VSSRef::Color)), vssReferee, SLOT(teamSent(VSSRef::Color)), Qt::DirectConnection);
 
     // Half connection
-    QObject::connect(vssReferee, SIGNAL(halfPassed()), refView->getUI(), SLOT(switchSides()), Qt::DirectConnection);
+    //QObject::connect(vssReferee, SIGNAL(halfPassed()), refView->getUI(), SLOT(switchSides()), Qt::DirectConnection);
 
     // Goalie connection
     QObject::connect(vssReferee, SIGNAL(sendGoalie(VSSRef::Color, int)), vssReplacer, SLOT(takeGoalie(VSSRef::Color, int)), Qt::DirectConnection);


### PR DESCRIPTION
* Removed side switch when an round is over (as requested by teams feedback)
* Added teamName for team blue and yellow (respectively) on binary params. To check how to, use `./VSS-Referee -h`  